### PR TITLE
Update a few links to M1 advent calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ This application was created to serve as a reusable advent calendar for students
 ### M1
 * [Day One - JavaScript Array](https://repl.it/@HannahHudson1/AdventDay1#index.js)
 * [Day Two - JavaScript DOM](https://codepen.io/hannahhch/pen/OJXGpxJ)
-* [Day Three - Work on Mythicals](https://gist.github.com/kaylagordon/6a0a0640c3dcf7e3f998bb078d7b339d)
+* [Day Three - Work on Mythicals](https://gist.github.com/Kalikoze/0544683112bd0c0381f634c8cdda6c42)
 * [Day Four - HTML & CSS](https://github.com/turingschool-examples/cookie-comp)
 * [Day Five - JavaScript Array](https://repl.it/@HannahHudson1/Advent5#index.js)
 * [Day Six - HTML, CSS & JS Refactoring](https://codepen.io/hannahhch/pen/QWEPeKb)
-* [Day Seven - HTML & CSS](https://codepen.io/hannahhch/pen/mdEYqjX)
+* [Day Seven - HTML & CSS](https://codepen.io/Kalikoze/pen/abXVrpK)
 * [Day Eight - JavaScript Object](https://repl.it/@HannahHudson1/Advent8)
-* [Day Nine - Work on Mythicals](https://gist.github.com/kaylagordon/6a0a0640c3dcf7e3f998bb078d7b339d)
+* [Day Nine - Work on Mythicals](https://gist.github.com/Kalikoze/5c51aae50247fe03de0edc591159b737)
 * [Day Ten - HTML, CSS and JS Dom Manipulation](https://github.com/turingschool-examples/winter-mad-libs)
 
 ### M2


### PR DESCRIPTION
Closes Issue #743

**Need from Reviewers**

- Double check that the new links are public.
- Make sure that the codepen link is running a countdown timer for the new year!
- Let me know if I missed anything!  There weren't any notes about classes or OOP that I found in the M1 advent calendar aside from continuing to work on the javascript foundations.

---


**Description of changes made**

- Updated the Gist links for JS foundations so that they no longer reference Mythical creatures as much (_given that there are only 3 test suites in there now and by this point, most students will have worked through them_)
- Updated the Codepen link so that the countdown was working correctly.  (_the last time this had been updated was for the year 2020_)
